### PR TITLE
Experiment: Page-Fault-Based Working Set Limit in 64-Bit Main Memory

### DIFF
--- a/rs/embedders/src/signal_handler.rs
+++ b/rs/embedders/src/signal_handler.rs
@@ -1,5 +1,8 @@
 use crate::wasmtime_embedder::host_memory::MemoryPageSize;
+use crate::wasmtime_embedder::MAIN_MEMORY_PAGE_ACCESS_LIMIT;
 
+use ic_interfaces::execution_environment::HypervisorResult;
+use ic_replicated_state::EmbedderCache;
 use libc::c_void;
 use memory_tracker::{signal_access_kind_and_address, SigsegvMemoryTracker};
 use std::convert::TryFrom;
@@ -8,6 +11,7 @@ use std::sync::{atomic::Ordering, Arc, Mutex};
 
 /// Helper function to create a memory tracking SIGSEGV handler function.
 pub(crate) fn sigsegv_memory_tracker_handler(
+    cache: EmbedderCache,
     memories: Vec<(Arc<Mutex<SigsegvMemoryTracker>>, MemoryPageSize)>,
 ) -> impl Fn(i32, *const libc::siginfo_t, *const libc::c_void) -> bool + Send + Sync {
     let mut memories: Vec<_> = memories
@@ -69,6 +73,17 @@ pub(crate) fn sigsegv_memory_tracker_handler(
             .unwrap_or(&memories[0]);
 
         let mut memory_tracker = memory_tracker.lock().unwrap();
+
+        // Limiting the number of page accesses in 64-bit main memory support.
+        // This is done by interrupting the wasmtime engine in a controlled way by using the epoch mechanism.
+        if memory_tracker.num_accessed_pages() as u64 > MAIN_MEMORY_PAGE_ACCESS_LIMIT {
+            let module = cache
+                .downcast::<HypervisorResult<wasmtime::Module>>()
+                .unwrap()
+                .as_ref()
+                .unwrap();
+            module.engine().increment_epoch();
+        }
 
         // We handle SIGSEGV from the Wasm module heap ourselves.
         if memory_tracker.area().is_within(si_addr) {

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -17,7 +17,7 @@ use wasmtime::{
 };
 
 pub use host_memory::WasmtimeMemoryCreator;
-use ic_config::embedders::MeteringType;
+use ic_config::embedders::{MeteringType, STABLE_MEMORY_ACCESSED_PAGE_LIMIT};
 use ic_config::{embedders::Config as EmbeddersConfig, flag_status::FlagStatus};
 use ic_interfaces::execution_environment::{
     HypervisorError, HypervisorResult, InstanceStats, SystemApi, TrapCode,
@@ -48,6 +48,10 @@ use self::host_memory::{MemoryPageSize, MemoryStart};
 
 #[cfg(test)]
 mod wasmtime_embedder_tests;
+
+/// Used for 64-bit main memory support:
+/// Limit for the number of pages accessed in a single message.
+pub const MAIN_MEMORY_PAGE_ACCESS_LIMIT: u64 = STABLE_MEMORY_ACCESSED_PAGE_LIMIT;
 
 const BAD_SIGNATURE_MESSAGE: &str = "function invocation does not match its signature";
 pub(crate) const WASM_HEAP_MEMORY_NAME: &str = "memory";
@@ -100,6 +104,10 @@ fn trap_code_to_hypervisor_error(trap: wasmtime::Trap) -> HypervisorError {
             HypervisorError::Trapped(TrapCode::IntegerDivByZero)
         }
         wasmtime::Trap::UnreachableCodeReached => HypervisorError::Trapped(TrapCode::Unreachable),
+        wasmtime::Trap::Interrupt => HypervisorError::MemoryAccessLimitExceeded(
+            format!("Exceeded the limit for the number of modified pages in the main memory in a single message execution: limit: {} KB.",
+                MAIN_MEMORY_PAGE_ACCESS_LIMIT * PAGE_SIZE as u64 / 1024),
+            ),
         _ => {
             // The `wasmtime::TrapCode` enum is marked as #[non_exhaustive]
             // so we have to use the wildcard matching here.
@@ -194,6 +202,8 @@ impl WasmtimeEmbedder {
     pub fn initial_wasmtime_config(embedder_config: &EmbeddersConfig) -> wasmtime::Config {
         let mut config = wasmtime::Config::default();
         config.cranelift_opt_level(OptLevel::None);
+        // The epoch mechanism is used for limiting the number of page accesses in 64-bit main memory support.
+        config.epoch_interruption(true);
         ensure_determinism(&mut config);
         disable_unused_features(&mut config);
         if embedder_config.feature_flags.write_barrier == FlagStatus::Enabled
@@ -440,7 +450,8 @@ impl WasmtimeEmbedder {
                 self.instantiate_memory(memory_info, &instance, store, &mut memories, canister_id)?;
         }
 
-        let memory_trackers = sigsegv_memory_tracker(memories, &mut store, self.log.clone());
+        let memory_trackers =
+            sigsegv_memory_tracker(cache.clone(), memories, &mut store, self.log.clone());
 
         let signal_stack = WasmtimeSignalStack::new();
         Ok(WasmtimeInstance {
@@ -596,6 +607,7 @@ pub struct MemorySigSegvInfo {
 }
 
 fn sigsegv_memory_tracker<S>(
+    cache: EmbedderCache,
     memories: HashMap<CanisterMemoryType, MemorySigSegvInfo>,
     store: &mut wasmtime::Store<S>,
     log: ReplicaLogger,
@@ -638,7 +650,9 @@ fn sigsegv_memory_tracker<S>(
         tracked_memories.push((sigsegv_memory_tracker, current_memory_size_in_pages));
     }
 
-    let handler = crate::signal_handler::sigsegv_memory_tracker_handler(tracked_memories);
+    // The epoch mechanism is used for limiting the number of page accesses in 64-bit main memory support.
+    store.set_epoch_deadline(1);
+    let handler = crate::signal_handler::sigsegv_memory_tracker_handler(cache, tracked_memories);
     // http://man7.org/linux/man-pages/man7/signal-safety.7.html
     unsafe {
         store.set_signal_handler(handler);

--- a/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/wasmtime_embedder_tests.rs
@@ -83,6 +83,7 @@ fn test_wasmtime_system_api() {
             num_instructions_global: None,
         },
     );
+    store.set_epoch_deadline(1);
 
     let wat = r#"
     (module

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -418,9 +418,11 @@ fn wat2wasm(wat: &str) -> Result<BinaryEncodedWasm, wat::Error> {
 mod tests {
     use super::*;
 
-    use ic_embedders::{wasm_executor::compute_page_delta, wasmtime_embedder::CanisterMemoryType};
+    use ic_embedders::{
+        wasm_executor::compute_page_delta, wasmtime_embedder::CanisterMemoryType, InstanceRunResult,
+    };
     // Get .current() trait method
-    use ic_interfaces::execution_environment::{HypervisorError, SystemApi};
+    use ic_interfaces::execution_environment::{HypervisorError, HypervisorResult, SystemApi};
     use ic_logger::ReplicaLogger;
     use ic_replicated_state::{PageIndex, PageMap};
     use ic_system_api::ModificationTracking;
@@ -1374,5 +1376,93 @@ mod tests {
             apply_writes_and_check_heap(&writes, ModificationTracking::Track, &wat, false)
         }
         apply_writes_and_check_heap(&writes, ModificationTracking::Ignore, &wat, false);
+    }
+
+    fn run_wasm(wat: &str, function_name: &str) -> HypervisorResult<InstanceRunResult> {
+        with_test_replica_logger(|log| {
+            let wasm = wat::parse_str(wat).map(BinaryEncodedWasm::new).unwrap();
+            let embedder = WasmtimeEmbedder::new(ic_config::embedders::Config::default(), log);
+            let (embedder_cache, result) = compile(&embedder, &wasm);
+            result.unwrap();
+            let api = test_api_for_update(
+                no_op_logger(),
+                None,
+                vec![],
+                SubnetType::Application,
+                NumInstructions::new(10_000_000_000),
+            );
+            let instruction_limit = api.slice_instruction_limit();
+            let memory = Memory::new(PageMap::new_for_testing(), NumWasmPages::from(0));
+            let mut instance = embedder
+                .new_instance(
+                    canister_test_id(1),
+                    &embedder_cache,
+                    None,
+                    &memory.clone(),
+                    &memory,
+                    ModificationTracking::Ignore,
+                    api,
+                )
+                .map_err(|r| r.0)
+                .expect("Failed to create instance");
+            instance.set_instruction_counter(i64::try_from(instruction_limit.get()).unwrap());
+            instance.run(FuncRef::Method(WasmMethod::Update(
+                function_name.to_string(),
+            )))
+        })
+    }
+
+    #[test]
+    fn check_64bit_working_set_limit_by_reading() {
+        let wat = r#"
+                (module
+                    (func (export "canister_update test")
+                        (local $address i64)
+                        loop
+                            local.get $address
+                            i64.load
+                            drop
+                            local.get $address
+                            i64.const 4096 ;; OS page
+                            i64.add
+                            local.set $address
+                            br 0
+                        end
+                    )
+                    (memory i64 131073) ;; 8 GB working set limit + 1 Wasm page
+                )
+            "#;
+        let result = run_wasm(wat, "test");
+        match result.unwrap_err() {
+            HypervisorError::MemoryAccessLimitExceeded(_) => {}
+            other_error => panic!("Unexpected error: {other_error:?}"),
+        }
+    }
+
+    #[test]
+    fn check_64bit_working_set_limit_by_writing() {
+        let wat = r#"
+                (module
+                    (func (export "canister_update test")
+                        (local $address i64)
+                        loop
+                            local.get $address
+                            i64.const 0
+                            i64.store
+                            local.get $address
+                            i64.const 4096 ;; OS page
+                            i64.add
+                            local.set $address
+                            br 0
+                        end
+                    )
+                    (memory i64 131073) ;; 8 GB working set limit + 1 Wasm page
+                )
+            "#;
+        let result = run_wasm(wat, "test");
+        match result.unwrap_err() {
+            HypervisorError::MemoryAccessLimitExceeded(_) => {}
+            other_error => panic!("Unexpected error: {other_error:?}"),
+        }
     }
 }

--- a/rs/embedders/tests/wasmtime_simple.rs
+++ b/rs/embedders/tests/wasmtime_simple.rs
@@ -102,7 +102,8 @@ impl WasmtimeSimple {
             &EmbeddersConfig::default(),
         ))
         .expect("Failed to initialize Wasmtime engine");
-        let store = Store::new(&engine, ());
+        let mut store = Store::new(&engine, ());
+        store.set_epoch_deadline(1);
         Self { engine, store }
     }
 


### PR DESCRIPTION
# Experiment: Page-Fault-Based Working Set Limit in 64-Bit Main Memory

**Note**: This is only an experiment, that is probably not feasible because of potential non-deterministic page-fault handler behavior in the IC runtime system.

Addition to the PR implementing IC support for Enhanced Orthogonal Persistence: https://github.com/dfinity/ic/pull/143

## Implementation
* Limit the number of accessed pages per IC message.
* Tracking number of accessed pages in the page fault handler.
* Cooperatively interrupting the `wasmtime` engine when the limit is exceeded, using the `wasmtime` `epoch` mechanism.

## Deterministic Alternative
Instrumentation-Based Limit: https://github.com/luc-blaeser/ic/pull/1